### PR TITLE
Force all paths to use forward slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,11 +76,11 @@ module.exports = function (files, opts) {
             globals.global = 'window';
         }
         if (scope.globals.implicit.indexOf('__filename') >= 0) {
-            var file = '/' + path.relative(basedir, row.id);
+            var file = '/' + path.relative(basedir, row.id).replace(/\\/g, '/');
             globals.__filename = JSON.stringify(file);
         }
         if (scope.globals.implicit.indexOf('__dirname') >= 0) {
-            var dir = path.dirname('/' + path.relative(basedir, row.id));
+            var dir = path.dirname('/' + path.relative(basedir, row.id)).replace(/\\/g, '/');
             globals.__dirname = JSON.stringify(dir);
         }
         


### PR DESCRIPTION
Don't expose Windows-style paths in the browser.  (especially since the browser-side `path` module won't recognize backslahses)

I am ignoring the possibility of a Linux path with a `\` in it.