### PR TITLE
Replace backslash with slash in sourcemap path

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ function closeOver (globals, src, file, opts) {
     if (!opts.debug) {
         return wrappedSource;
     }
-    var sourceFile = path.relative(opts.basedir, file);
+    var sourceFile = path.relative(opts.basedir, file)
+        .replace(/\\/g, '/');
     var sourceMap = combineSourceMap.create().addFile(
         { sourceFile: sourceFile, source: src},
         { line: 1 });


### PR DESCRIPTION
For Windows compatibility.
This is already done in browserify: https://github.com/substack/node-browserify/blob/9.0.3/index.js#L719 but that only applies to modules which don't use globals.
With this patch, Chrome shows a nice folder structure for all source files (not only some), on Windows.
See also: mozilla/source-map#91 substack/insert-module-globals#7