### PR TITLE
Turn backslashes of __dirname and __filename into slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ var defaultVars = {
         return 'require("buffer").Buffer';
     },
     __filename: function (file, basedir) {
-        var file = '/' + path.relative(basedir, file);
+        var file = '/' + path.relative(basedir, file).replace(/\\/g, '/');
         return JSON.stringify(file);
     },
     __dirname: function (file, basedir) {
-        var dir = path.dirname('/' + path.relative(basedir, file));
+        var dir = path.dirname('/' + path.relative(basedir, file).replace(/\\/g, '/'));
         return JSON.stringify(dir);
     }
 };


### PR DESCRIPTION
Under Windows, fix test cases 3 of insert.js and 3 of return.js

Also correct browserify's test case 7 of global.js