### PR TITLE
Update deps & more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_install:
   - npm install -g npm@~1.4.6

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "tap": "~0.4.0",
     "browser-pack": "~0.10.2",
-    "module-deps": "~1.4.0",
-    "native-buffer-browserify": "~2.0.16"
+    "buffer": "^3.0.0",
+    "module-deps": "~1.4.0"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "insert-module-globals": "bin/cmd.js"
   },
   "dependencies": {
-    "JSONStream": "~0.7.1",
+    "JSONStream": "~0.10.0",
     "combine-source-map": "~0.3.0",
     "concat-stream": "~1.4.1",
     "lexical-scope": "~1.1.0",
-    "process": "~0.6.0",
+    "process": "^0.10.0",
     "through": "~2.3.4",
-    "xtend": "^3.0.0"
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "tap": "~0.4.0",

--- a/test/always.js
+++ b/test/always.js
@@ -11,7 +11,7 @@ test('always insert', function (t) {
     var s = mdeps(files, {
         transform: inserter,
         modules: {
-            buffer: require.resolve('native-buffer-browserify')
+            buffer: require.resolve('buffer/')
         }
     });
     s.pipe(bpack({ raw: true })).pipe(concat(function (src) {

--- a/test/insert.js
+++ b/test/insert.js
@@ -22,7 +22,7 @@ test('buffer inserts', function (t) {
     var files = [ __dirname + '/insert/buffer.js' ];
     var s = mdeps(files, {
         transform: [ inserter ],
-        modules: { buffer: require.resolve('native-buffer-browserify') }
+        modules: { buffer: require.resolve('buffer/') }
     });
     s.pipe(bpack({ raw: true })).pipe(concat(function (src) {
         var c = {


### PR DESCRIPTION
* Sync's travis node versions with browserify
* Use buffer not native-buffer-browserify in tests (to remove the ugly deprecated notice)
* Update deps
  * JSONStream to ~0.10.0
    * This part of https://github.com/substack/node-browserify/issues/707#issuecomment-96273418. Unfortunately we can't update to JSONStream@^1.0.1 (see https://github.com/dominictarr/JSONStream/pull/67), so ~0.10.0 will have to do.
  * process to ^0.10.0 (same as browserify)
    * Can't update to 0.11.0 right now because `process.nextTick` does some cleanup that is throwing in the tests. That's because the tests use `vm.runInNewContext` - we have to use `Function(...)` so we can do async stuff.
    * And yeah `^` for 0.x.x because that's what browserify has :(
  * xtend to ^4.0.0