### PR TITLE
Update process to ~0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "combine-source-map": "~0.3.0",
     "concat-stream": "~1.4.1",
     "lexical-scope": "~1.1.0",
-    "process": "^0.10.0",
+    "process": "~0.11.0",
     "through": "~2.3.4",
     "xtend": "^4.0.0"
   },

--- a/test/insert.js
+++ b/test/insert.js
@@ -12,7 +12,11 @@ test('process.nextTick inserts', function (t) {
         .pipe(bpack({ raw: true }))
     ;
     s.pipe(concat(function (src) {
-        var c = { t: t, setTimeout: setTimeout };
+        var c = {
+            t: t,
+            setTimeout: setTimeout,
+            clearTimeout: clearTimeout
+        };
         vm.runInNewContext(src, c);
     }));
 });
@@ -28,6 +32,7 @@ test('buffer inserts', function (t) {
         var c = {
             t: t,
             setTimeout: setTimeout,
+            clearTimeout: clearTimeout,
             Uint8Array: Uint8Array,
             DataView: DataView
         };

--- a/test/return.js
+++ b/test/return.js
@@ -12,7 +12,11 @@ test('early return', function (t) {
         .pipe(bpack({ raw: true }))
     ;
     s.pipe(concat(function (src) {
-        var c = { t: t, setTimeout: setTimeout };
+        var c = {
+            t: t,
+            setTimeout: setTimeout,
+            clearTimeout: clearTimeout
+        };
         vm.runInNewContext(src, c);
     }));
 });


### PR DESCRIPTION
The reason for having to pass in `clearTimeout` into the context in tests is because there is now a queue in `process.nextTick` that depends on it (see https://github.com/defunctzombie/node-process/pull/38 and https://github.com/defunctzombie/node-process/compare/v0.10.1...v0.11.0.).

Follow up to https://github.com/substack/node-browserify/pull/1231 - this PR is just for completeness, browserify doesn't use the `process` from this module (it [passes](https://github.com/substack/node-browserify/blob/96d1662536cdf98f5c124c8d64616e77e3283c61/index.js#L533) its own).