### PR TITLE
Add BOM removing

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,9 @@ module.exports = function (file, opts) {
             ? Buffer.concat(chunks).toString('utf8')
             : chunks.join('')
         ;
-        source = source.replace(/^#![^\n]*\n/, '\n');
+        source = source
+            .replace(/^\ufeff/, '')
+            .replace(/^#![^\n]*\n/, '\n');
         
         if (opts.always !== true && !quick.test(source)) {
             this.queue(source);

--- a/test/unprefix.js
+++ b/test/unprefix.js
@@ -1,0 +1,32 @@
+var test = require('tap').test;
+var vm = require('vm');
+var concat = require('concat-stream');
+
+var insert = require('../');
+var bpack = require('browser-pack');
+var mdeps = require('module-deps');
+
+test('unprefix - remove shebang and bom', function (t) {
+    t.plan(3);
+    
+    var file = __dirname + '/unprefix/main.js';
+    var deps = mdeps({ transform: inserter });
+    var pack = bpack({ raw: true });
+    
+    deps.pipe(pack);
+    
+    pack.pipe(concat(function (src) {
+        var c = {};
+        vm.runInNewContext('require=' + src, c);
+        var x = c.require(file);
+        t.equal(x.filename, '/hello.js');
+        t.equal(x.dirname, '/');
+        t.notSimilar(src.toString(), /\ufeff/);
+    }));
+    
+    deps.end(file);
+});
+
+function inserter (file) {
+    return insert(file, { basedir: __dirname + '/unprefix' });
+}

--- a/test/unprefix/hello.js
+++ b/test/unprefix/hello.js
@@ -1,0 +1,2 @@
+﻿exports.filename = __filename;
+exports.dirname = __dirname;

--- a/test/unprefix/main.js
+++ b/test/unprefix/main.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+module.exports = require('./hello');


### PR DESCRIPTION
un-BOM-ing has to happen here because if close over the module because it has globals, then the BOM is no longer the first character, and it won't get removed by browserify.

Fixes https://github.com/substack/node-browserify/issues/1263

cc: @jmm