### PR TITLE
Update combine-source-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insert-module-globals",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "description": "insert implicit module globals into a module-deps stream",
   "main": "index.js",
   "bin": {
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.0.3",
-    "combine-source-map": "~0.3.0",
+    "combine-source-map": "~0.6.1",
     "concat-stream": "~1.4.1",
     "lexical-scope": "~1.1.0",
     "process": "~0.11.0",


### PR DESCRIPTION
Update combine-source-map dependency and bump minor version.
Downstream versions are erroring out in the 0.3.x chain.

fixes the following error:
```
Error: Cannot find module './source-map/source-map-generator'
    at Function.Module._resolveFilename (module.js:332:15)
    at Function.Module._load (module.js:282:25)
    at Module.require (module.js:361:17)
    at require (module.js:380:17)
    at Object.<anonymous> (P:\src\svn2.inxsol.com\hazready\trunk\Source\Hazready_VS\ExposureTrack.Website\_components\node_modules\browserify\node_modules\insert-module-globals\node_modules\combine-source-map\node_modules\inline-source-map\node_modules\source-map\lib\source-map.js:6:30)
    at Module._compile (module.js:426:26)
    at Object.Module._extensions..js (module.js:444:10)
    at Module.load (module.js:351:32)
    at Function.Module._load (module.js:306:12)
    at Module.require (module.js:361:17)
    at require (module.js:380:17)
```