### PR TITLE
Hide full filesystem paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ var isbufferPath = require.resolve('is-buffer')
 var combineSourceMap = require('combine-source-map');
 
 var defaultVars = {
-    process: function () {
-        return 'require(' + JSON.stringify(processPath) + ')';
+    process: function (file) {
+        var relpath = path.relative(path.dirname(file), processPath);
+        return 'require(' + JSON.stringify(relpath) + ')';
     },
     global: function () {
         return 'typeof global !== "undefined" ? global : '
@@ -17,8 +18,9 @@ var defaultVars = {
             + 'typeof window !== "undefined" ? window : {}'
         ;
     },
-    'Buffer.isBuffer': function () {
-        return 'require(' + JSON.stringify(isbufferPath) + ')';
+    'Buffer.isBuffer': function (file) {
+        var relpath = path.relative(path.dirname(file), isbufferPath);
+        return 'require(' + JSON.stringify(relpath) + ')';
     },
     Buffer: function () {
         return 'require("buffer").Buffer';

--- a/index.js
+++ b/index.js
@@ -7,9 +7,17 @@ var processPath = require.resolve('process/browser.js');
 var isbufferPath = require.resolve('is-buffer')
 var combineSourceMap = require('combine-source-map');
 
+function getRelativePath(fullPath, fromPath) {
+  var relpath = path.relative(path.dirname(fromPath), fullPath);
+  if (relpath[0] !== "." && relpath[0] !== "/") {
+    relpath = "./" + relpath;
+  }
+  return relpath;
+}
+
 var defaultVars = {
     process: function (file) {
-        var relpath = path.relative(path.dirname(file), processPath);
+        var relpath = getRelativePath(processPath, file);
         return 'require(' + JSON.stringify(relpath) + ')';
     },
     global: function () {
@@ -19,7 +27,7 @@ var defaultVars = {
         ;
     },
     'Buffer.isBuffer': function (file) {
-        var relpath = path.relative(path.dirname(file), isbufferPath);
+        var relpath = getRelativePath(isbufferPath, file);
         return 'require(' + JSON.stringify(relpath) + ')';
     },
     Buffer: function () {

--- a/test/isbuffer.js
+++ b/test/isbuffer.js
@@ -6,7 +6,7 @@ var concat = require('concat-stream');
 var vm = require('vm');
 
 test('isbuffer', function (t) {
-    t.plan(4);
+    t.plan(5);
     var deps = mdeps()
     var pack = bpack({ raw: true, hasExports: true });
     deps.pipe(pack).pipe(concat(function (src) {
@@ -16,6 +16,7 @@ test('isbuffer', function (t) {
         t.equal(c.require('main')('wow'), false, 'not a buffer (string)');
         t.equal(c.require('main')({}), false, 'not a buffer (object)');
         t.notOk(/require("buffer")/.test(src), 'buffer not required in source')
+        t.notOk(/require\("\//.test(src), 'absolute path not required in source')
     }));
     deps.write({ transform: inserter, global: true });
     deps.end({ id: 'main', file: __dirname + '/isbuffer/main.js' });


### PR DESCRIPTION
There is currently an issue when inserting `Buffer.isBuffer` where the full filesystem path to the `is-buffer` module is exposed in the bundle. See [this gist for an example to reproduce][gist]. Exposing full filesystem paths can be [security risk][risk].

[gist]: https://gist.github.com/parshap/ed918fb4a80ae5d271a0
[risk]: https://www.owasp.org/index.php/Full_Path_Disclosure
[b fix]: https://github.com/substack/node-browserify/commit/5fe121beb2de1c0bf795f2718737d4ead97fd70d

This changes the inserted `require(...)` call to use a relative path instead of an absolute path and adds a test to make sure no absolute paths are included.

This change also applies to inserting `process`. This was previously [fixed in browserify][b fix], which would no longer be needed.