### PR TITLE
Remove usage of path.posix for node 0.10 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ var isbufferPath = require.resolve('is-buffer')
 var combineSourceMap = require('combine-source-map');
 
 function getRelativeRequirePath(fullPath, fromPath) {
-  var relpath = path.posix.relative(path.dirname(fromPath), fullPath);
+  var relpath = path.relative(path.dirname(fromPath), fullPath);
   if (relpath[0] !== "." && relpath[0] !== "/") {
     relpath = "./" + relpath;
   }
-  return relpath;
+  return relpath.replace(/\\/g, '/');
 }
 
 var defaultVars = {


### PR DESCRIPTION
Fixes build in 0.10. Introduced in #56. Fixes #57. See https://travis-ci.org/substack/insert-module-globals/jobs/86008707.