### PR TITLE
Fix issue with "./" in require path on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ function getRelativeRequirePath(fullPath, fromPath) {
   if (path.dirname(relpath) === '.') {
     relpath = "./" + relpath;
   }
-  return relpath.replace(/\\/g, '/');
+  // On Windows: Convert path separators to what require() expects
+  if (path.sep === '\\') {
+    relpath = relpath.replace(/\\/g, '/');
+  }
+  return relpath;
 }
 
 var defaultVars = {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,10 @@ var combineSourceMap = require('combine-source-map');
 
 function getRelativeRequirePath(fullPath, fromPath) {
   var relpath = path.relative(path.dirname(fromPath), fullPath);
-  if (relpath[0] !== "." && relpath[0] !== "/") {
+  // If fullPath is in the same directory as fromPath, relpath will
+  // result in something like "index.js". require() needs "./" prepended
+  // to these paths.
+  if (path.dirname(relpath) === '.') {
     relpath = "./" + relpath;
   }
   return relpath.replace(/\\/g, '/');


### PR DESCRIPTION
The check for `relpath` starting with `'.'` or `'/'` does not work on Windows, as paths can start with a drive letter (e.g., `'C:\'`). Now `path.dirname()` is used to determine if prepending `'./'` is necessary.

See #59.

Also snuck a commit in there to only convert path separators from `'\'` to `'/'` if on Windows.