### PR TITLE
Remove redundant - window - reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,7 @@ var defaultVars = {
     },
     global: function () {
         return 'typeof global !== "undefined" ? global : '
-            + 'typeof self !== "undefined" ? self : '
-            + 'typeof window !== "undefined" ? window : {}'
-        ;
+            + 'typeof self !== "undefined" ? self : {}';
     },
     'Buffer.isBuffer': function (file) {
         var relpath = getRelativeRequirePath(isbufferPath, file);


### PR DESCRIPTION
Note: self is the same as window, except in workers (where there is no window). In either case they are likely to reference the global object, but it would be better to avoid host objects entirely.