### PR TITLE
make paths relative

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,11 +41,11 @@ var defaultVars = {
         return 'require("buffer").Buffer';
     },
     __filename: function (file, basedir) {
-        var filename = '/' + path.relative(basedir, file);
+        var filename = './' + path.relative(basedir, file);
         return JSON.stringify(filename);
     },
     __dirname: function (file, basedir) {
-        var dir = path.dirname('/' + path.relative(basedir, file));
+        var dir = path.dirname('./' + path.relative(basedir, file));
         return JSON.stringify(dir);
     }
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -25,24 +25,24 @@ mdeps(files, { transform: inserter })
 
 ```
 $ node example/insert.js | node
-in main.js: {"__filename":"/main.js","__dirname":"/"}
-in foo/index.js: {"__filename":"/foo/index.js","__dirname":"/foo"}
+in main.js: {"__filename":"./main.js","__dirname":"."}
+in foo/index.js: {"__filename":"./foo/index.js","__dirname":"./foo"}
 ```
 
 or use the command-line scripts:
 
 ```
 $ module-deps main.js | insert-module-globals | browser-pack | node
-in main.js: {"__filename":"/main.js","__dirname":"/"}
-in foo/index.js: {"__filename":"/foo/index.js","__dirname":"/foo"}
+in main.js: {"__filename":"./main.js","__dirname":"."}
+in foo/index.js: {"__filename":"./foo/index.js","__dirname":"./foo"}
 ```
 
 or use insert-module-globals as a transform:
 
 ```
 $ module-deps main.js --transform insert-module-globals | browser-pack | node
-in main.js: {"__filename":"/main.js","__dirname":"/"}
-in foo/index.js: {"__filename":"/foo/index.js","__dirname":"/foo"}
+in main.js: {"__filename":"./main.js","__dirname":"."}
+in foo/index.js: {"__filename":"./foo/index.js","__dirname":"./foo"}
 ```
 
 # methods

--- a/test/global.js
+++ b/test/global.js
@@ -50,8 +50,8 @@ test('__filename and __dirname', function (t) {
         var c = {};
         vm.runInNewContext('require=' + src, c);
         var x = c.require(file);
-        t.equal(x.filename, '/filename.js');
-        t.equal(x.dirname, '/');
+        t.equal(x.filename, './filename.js');
+        t.equal(x.dirname, '.');
     }));
     
     deps.write({ transform: inserter, global: true });

--- a/test/insert/foo/index.js
+++ b/test/insert/foo/index.js
@@ -1,4 +1,4 @@
 process.nextTick(function () {
-    t.equal(__filename, '/foo/index.js');
-    t.equal(__dirname, '/foo');
+    t.equal(__filename, './foo/index.js');
+    t.equal(__dirname, './foo');
 });

--- a/test/insert/main.js
+++ b/test/insert/main.js
@@ -1,4 +1,4 @@
-t.equal(__filename, '/main.js');
-t.equal(__dirname, '/');
+t.equal(__filename, './main.js');
+t.equal(__dirname, '.');
 
 require('./foo');

--- a/test/return/foo/index.js
+++ b/test/return/foo/index.js
@@ -1,4 +1,4 @@
 process.nextTick(function () {
-    t.equal(__filename, '/foo/index.js');
-    t.equal(__dirname, '/foo');
+    t.equal(__filename, './foo/index.js');
+    t.equal(__dirname, './foo');
 });

--- a/test/return/main.js
+++ b/test/return/main.js
@@ -1,5 +1,5 @@
-t.equal(__filename, '/main.js');
-t.equal(__dirname, '/');
+t.equal(__filename, './main.js');
+t.equal(__dirname, '.');
 
 require('./foo');
 

--- a/test/sourcemap.js
+++ b/test/sourcemap.js
@@ -23,8 +23,8 @@ test('sourcemap', function (t) {
         var c = {
             console: {
                 log: function(dirname, filename) {
-                    t.equal(dirname, '/');
-                    t.equal(filename, '/main.js');
+                    t.equal(dirname, '.');
+                    t.equal(filename, './main.js');
                 }
             },
         };

--- a/test/unprefix.js
+++ b/test/unprefix.js
@@ -19,8 +19,8 @@ test('unprefix - remove shebang and bom', function (t) {
         var c = {};
         vm.runInNewContext('require=' + src, c);
         var x = c.require(file);
-        t.equal(x.filename, '/hello.js');
-        t.equal(x.dirname, '/');
+        t.equal(x.filename, './hello.js');
+        t.equal(x.dirname, '.');
         t.notOk(/\ufeff/.test(src.toString()));
     }));
     


### PR DESCRIPTION
I need bundled paths to be relative for [dat-desktop](https://github.com/dat-project/dat-desktop), which is an electron app using browserify because it needs browserify transforms.

I can't pass `--no-commondir` to browserify, because that would make file paths specific to the machine the bundle was created on (e.g. `/Users/julian/...`), and without this patch, `__dirname` in the bundle would be `/lib/foo.js` etc, which doesn't work with say calls do `fs.readFile()`.

Since it seems unimportant whether in a browser bundle the paths are `/foo` or `./foo`, I think this patch can be applied without adding an option for relative paths.